### PR TITLE
Read Full Response and Remove Defer Statement

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -161,9 +163,9 @@ func isListening(client *http.Client, url string) bool {
 	req.Close = true
 
 	resp, err := client.Do(req)
-
 	if resp != nil {
-		defer resp.Body.Close()
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
 	}
 
 	if err != nil {


### PR DESCRIPTION
The `isListening` function does not reads http bodies which may & do lead to error saying `Too many open file descriptors` as the connection does not gets closed. Adding an `io.Copy` to copy the response to ioutil.Discard solves the problem.

The second thing i did was remove the usage of defer from that code path as calling defer is more expensive than a simple statement.