### PR TITLE
Better -p Option Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,23 @@ https://example.net
 ## Extra Probes
 
 By default httprobe checks for HTTP on port 80 and HTTPS on port 443. You can add additional
-probes with the `-p` flag by specifying a protocol and port pair:
+probes with the `-p` flag by specifying a protocol and a comma-delimited port list pair:
 
 ```
-▶ cat domains.txt | httprobe -p http:81 -p https:8443
+▶ cat domains.txt | httprobe -p http:81,8080,8081 -p https:8443
+```
+
+If you want to probe some ports on both HTTP and HTTPS, then you can omit the protocol:
+
+```
+▶ cat domains.txt | httprobe -p 1234,4321,8088
+```
+
+You can probe a pre-defined list of ports that are commonly used for HTTP(S) by using the keywords `large` and `xlarge`:
+
+```
+▶ cat domains.txt | httprobe -p large
+▶ cat domains.txt | httprobe -p https:large,1234 -p http:xlarge
 ```
 
 ## Concurrency

--- a/main.go
+++ b/main.go
@@ -15,15 +15,71 @@ import (
 	"time"
 )
 
-type probeArgs []string
+type probeArgs struct {
+
+	httpPorts	[]string
+	httpsPorts	[]string
+
+}
 
 func (p *probeArgs) Set(val string) error {
-	*p = append(*p, val)
+
+	// Adding port templates
+	xlarge := []string{"81", "300", "591", "593", "832", "981", "1010", "1311", "2082", "2087", "2095", "2096", "2480", "3000", "3128", "3333", "4243", "4567", "4711", "4712", "4993", "5000", "5104", "5108", "5800", "6543", "7000", "7396", "7474", "8000", "8001", "8008", "8014", "8042", "8069", "8080", "8081", "8088", "8090", "8091", "8118", "8123", "8172", "8222", "8243", "8280", "8281", "8333", "8443", "8500", "8834", "8880", "8888", "8983", "9000", "9043", "9060", "9080", "9090", "9091", "9200", "9443", "9800", "9981", "12443", "16080", "18091", "18092", "20720", "28017"}
+	large := []string{"81", "591", "2082", "2087", "2095", "2096", "3000", "8000", "8001", "8008", "8080", "8083", "8443", "8834", "8888"}
+
+	pair := strings.SplitN(val, ":", 2)
+	if len(pair) == 1 {
+
+		// using `-p p1,p2...pn` format
+
+		fields := strings.Split(pair[0], ",")
+		for _, f := range fields {
+			if f == "large" {
+				p.httpPorts = append(p.httpPorts, large...)
+				p.httpsPorts = append(p.httpsPorts, large...)
+			} else if f == "xlarge" {
+				p.httpPorts = append(p.httpPorts, xlarge...)
+				p.httpsPorts = append(p.httpsPorts, xlarge...)
+			} else {
+				p.httpPorts = append(p.httpPorts, f)
+				p.httpsPorts = append(p.httpsPorts, f)
+			}
+		}
+
+	} else if len(pair) == 2 {
+
+		// using `-p proto:p1,p2...pn` format
+
+		proto := pair[0]
+		fields := strings.Split(pair[1], ",")
+		for _, f := range fields {
+			if proto == "https" {
+				if f == "large" {
+					p.httpsPorts = append(p.httpsPorts, large...)
+				} else if f == "xlarge" {
+					p.httpsPorts = append(p.httpsPorts, xlarge...)
+				} else {
+					p.httpsPorts = append(p.httpsPorts, f)
+				}
+			} else {
+				if f == "large" {
+					p.httpPorts = append(p.httpPorts, large...)
+				} else if f == "xlarge" {
+					p.httpPorts = append(p.httpPorts, xlarge...)
+				} else {
+					p.httpPorts = append(p.httpPorts, f)
+				}
+			}
+		}
+	}
+
 	return nil
+
 }
 
 func (p probeArgs) String() string {
-	return strings.Join(p, ",")
+	return strings.Join(append(p.httpPorts, p.httpsPorts...), ",")
 }
 
 func main() {
@@ -162,37 +218,21 @@ func main() {
 			httpsURLs <- domain
 		}
 
-		// Adding port templates
-		xlarge := []string{"81", "300", "591", "593", "832", "981", "1010", "1311", "2082", "2087", "2095", "2096", "2480", "3000", "3128", "3333", "4243", "4567", "4711", "4712", "4993", "5000", "5104", "5108", "5800", "6543", "7000", "7396", "7474", "8000", "8001", "8008", "8014", "8042", "8069", "8080", "8081", "8088", "8090", "8091", "8118", "8123", "8172", "8222", "8243", "8280", "8281", "8333", "8443", "8500", "8834", "8880", "8888", "8983", "9000", "9043", "9060", "9080", "9090", "9091", "9200", "9443", "9800", "9981", "12443", "16080", "18091", "18092", "20720", "28017"}
-		large := []string{"81", "591", "2082", "2087", "2095", "2096", "3000", "8000", "8001", "8008", "8080", "8083", "8443", "8834", "8888"}
-
 		// submit any additional proto:port probes
-		for _, p := range probes {
-			switch p {
-			case "xlarge":
-				for _, port := range xlarge {
-					httpsURLs <- fmt.Sprintf("%s:%s", domain, port)
-				}
-			case "large":
-				for _, port := range large {
-					httpsURLs <- fmt.Sprintf("%s:%s", domain, port)
-				}
-			default:
-				pair := strings.SplitN(p, ":", 2)
-				if len(pair) != 2 {
-					continue
-				}
+		for _, p := range probes.httpsPorts {
 
-				// This is a little bit funny as "https" will imply an
-				// http check as well unless the --prefer-https flag is
-				// set. On balance I don't think that's *such* a bad thing
-				// but it is maybe a little unexpected.
-				if strings.ToLower(pair[0]) == "https" {
-					httpsURLs <- fmt.Sprintf("%s:%s", domain, pair[1])
-				} else {
-					httpURLs <- fmt.Sprintf("%s:%s", domain, pair[1])
-				}
-			}
+			// This is a little bit funny as "https" will imply an
+			// http check as well unless the --prefer-https flag is
+			// set. On balance I don't think that's *such* a bad thing
+			// but it is maybe a little unexpected.
+			httpsURLs <- fmt.Sprintf("%s:%s", domain, p)
+
+		}
+
+		for _, p := range probes.httpPorts {
+
+			httpURLs <- fmt.Sprintf("%s:%s", domain, p)
+
 		}
 	}
 


### PR DESCRIPTION
Hi Tom,

This pull request addresses the issue that you proposed about specifying a large number of ports being inconvenient given how values passed to the *-p* option are formatted (#3). The modifications that I made to httprobe allow the following to work:
```
$ cat domains.txt | httprobe -p 1234
$ cat domains.txt | httprobe -p 1234,4321
$ cat domains.txt | httprobe -p large
$ cat domains.txt | httprobe -p large,1234
$ cat domains.txt | httprobe -p http:1234 -p https:1234,4321
$ cat domains.txt | httprobe -p http:large -p https:xlarge,1234
```

Determining which ports to probe on each of HTTP and HTTPS now happens only once (when the flags are parsed). Prior to this, httprobe would run a switch case for each host which is a waste of a *few* CPU cycles (I say this sarcastically :D).

Also note that I made the relevant changes to the README.md file (including what's mentioned in #23).

Best Regards,
Adam