### PR TITLE
Add default proxy from environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 			Timeout:   timeout,
 			KeepAlive: time.Second,
 		}).DialContext,
+		Proxy:             http.ProxyFromEnvironment,
 	}
 
 	re := func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
Using `http.ProxyFromEnvironment` allows httprobe to use a proxy defined in `HTTP_PROXY` (and `HTTPS_PROXY`).