### PR TITLE
Filter out Cloudflare error pages + performance improvement

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,6 +168,11 @@ func main() {
 	for sc.Scan() {
 		domain := strings.ToLower(sc.Text())
 
+		// Skip unresolvable domains
+		if _, err := net.LookupIP(domain); err != nil {
+			continue
+		}
+
 		// submit standard port checks
 		if !skipDefault {
 			httpsURLs <- domain

--- a/main.go
+++ b/main.go
@@ -48,6 +48,10 @@ func main() {
 	var preferHTTPS bool
 	flag.BoolVar(&preferHTTPS, "prefer-https", false, "only try plain HTTP if HTTPS fails")
 
+	// filter out cloudflare error pages
+	var filterCloudflareErrors bool
+	flag.BoolVar(&filterCloudflareErrors, "filter-cf-errors", false, "Filter out Cloudflare error pages")
+
 	// HTTP method to use
 	var method string
 	flag.StringVar(&method, "method", "GET", "HTTP method to use")
@@ -56,6 +60,13 @@ func main() {
 
 	// make an actual time.Duration out of the timeout
 	timeout := time.Duration(to * 1000000)
+
+	var filterStrings []string
+
+	// Add Cloudflare signatures to filterStrings if filterCloudflareErrors
+	if filterCloudflareErrors {
+		filterStrings = append(filterStrings, "<center>cloudflare</center>", "cf_styles-css")
+	}
 
 	var tr = &http.Transport{
 		MaxIdleConns:      30,
@@ -96,7 +107,7 @@ func main() {
 
 				// always try HTTPS first
 				withProto := "https://" + url
-				if isListening(client, withProto, method) {
+				if isListening(client, withProto, method, filterStrings) {
 					output <- withProto
 
 					// skip trying HTTP if --prefer-https is set
@@ -120,7 +131,7 @@ func main() {
 		go func() {
 			for url := range httpURLs {
 				withProto := "http://" + url
-				if isListening(client, withProto, method) {
+				if isListening(client, withProto, method, filterStrings) {
 					output <- withProto
 					continue
 				}
@@ -210,7 +221,7 @@ func main() {
 	outputWG.Wait()
 }
 
-func isListening(client *http.Client, url, method string) bool {
+func isListening(client *http.Client, url, method string, filterStrings []string) bool {
 
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
@@ -222,8 +233,21 @@ func isListening(client *http.Client, url, method string) bool {
 
 	resp, err := client.Do(req)
 	if resp != nil {
-		io.Copy(ioutil.Discard, resp.Body)
-		resp.Body.Close()
+		defer resp.Body.Close()
+
+		if len(filterStrings) != 0 {
+			// Read the first 512 bytes of the response and check for presence of any filter strings
+			peek := make([]byte, 512)
+			resp.Body.Read(peek)
+			peekStr := string(peek)
+			for _, filterString := range filterStrings {
+				if strings.Contains(peekStr, filterString) {
+					return true
+				}
+			}
+		} else {
+			io.Copy(ioutil.Discard, resp.Body)
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
**Happy New Year!** 🎉 

This PR adds a new `-filter-cf-errors` flag to httprobe which causes it to read the first 512 bytes from listening servers in order to determine if they are a "wildcard" response from Cloudflare like the ones shown here:

![Cloudflare error pages](https://i.imgur.com/QPk7vSt.png)

If a Cloudflare signature string is found, the function returns false to treat it as not listening. The functionality is implemented in a generic fashion so that it can easily be extended to filter out other common false-positive responses.

The PR also implements a small performance improvement by performing a DNS lookup on incoming domains and ignore the unresolvable ones to avoid filling up the job channels with dead domains. I timed the execution with a list containing 1483 resolveable and unresolvable domains with the `large` port list and was able to shave off 7 minutes of execution time, which is not a lot, but also not insignificant:

```bash
cat hosts.txt | time httprobe -t 2000 -p large
httprobe -t 2000 -p large  10.73s user 10.15s system 0% cpu 47:13.08 total

cat hosts.txt | time new-httprobe -t 2000 -p large
new-httprobe -t 2000 -p large  12.39s user 11.03s system 0% cpu 40:10.77 total

cat hosts.txt | time new-httprobe -t 2000 -filter-cf-errors -p large
new-httprobe -t 2000 -filter-cf-errors -p large  13.13s user 10.86s system 0% cpu 40:00.91 total
```