### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Take a list of domains and probe for working http and https servers.
 ## Install
 
 ```
-▶ go get -u github.com/tomnomnom/httprobe
+▶ go install github.com/tomnomnom/httprobe@latest
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Installing executables with "go get" in module mode is deprecated.
"go install pkg@version" should be used instead.
For more information, see https://golang.org/doc/go-get-install-deprecation