### PR TITLE
Automatically figure out whether to prepend http protocol to url or not

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,15 @@ func main() {
 			for url := range httpsURLs {
 
 				// always try HTTPS first
-				withProto := "https://" + url
+				var withProto string
+				// figure out if url has protocol, if not prepend the protocol
+				if url[0:8] == "https://" {
+					withProto = url
+				} else if url[0:7] == "http://" {
+					withProto = url
+				} else {
+					withProto = "https://" + url
+				}
 				if isListening(client, withProto, method) {
 					output <- withProto
 
@@ -119,7 +127,16 @@ func main() {
 
 		go func() {
 			for url := range httpURLs {
-				withProto := "http://" + url
+
+				var withProto string
+				// figure out if url has protocol, if not prepend protocol
+				if url[0:8] == "https://" {
+					withProto = url
+				} else if url[0:7] == "http://" {
+					withProto = url
+				} else {
+					withProto = "https://" + url
+				}
 				if isListening(client, withProto, method) {
 					output <- withProto
 					continue


### PR DESCRIPTION
Currently, the input url must be in the format:

```
google.com
xyz.com
```

Pushing code to automatically prepend the HTTP protocol if it is not present, or if its present don't error out, continue with that url.

All the below URL's are valid input now

```
http://google.com
google.com
https://google.com
```