### PR TITLE
updates install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Take a list of domains and probe for working http and https servers.
 ## Install
 
 ```
-▶ go install github.com/tomnomnom/httprobe@latest
+▶ go install github.com/tomnomnom/httprobe@master
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Hi, this PR should help with this issue: https://github.com/tomnomnom/httprobe/issues/43.
It just fixes `@latest` to `@master` version in installation instruction.
@ZishanAdThandar has already made a PR (https://github.com/tomnomnom/httprobe/pull/57), but now it closed.